### PR TITLE
Feat-makeTrail : 산책로 생성 기능 구현

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,9 +8,10 @@
         <entry key="app/src/main/res/drawable/ic_baseline_directions_walk_24.xml" value="0.1" />
         <entry key="app/src/main/res/drawable/ic_baseline_navigation_24.xml" value="0.1385" />
         <entry key="app/src/main/res/drawable/ic_baseline_near_me_24.xml" value="0.1875" />
+        <entry key="app/src/main/res/layout-v23/fragment_walk.xml" value="0.192481884057971" />
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.1" />
         <entry key="app/src/main/res/layout/fragment_setting.xml" value="0.14361702127659576" />
-        <entry key="app/src/main/res/layout/fragment_walk.xml" value="0.1" />
+        <entry key="app/src/main/res/layout/fragment_walk.xml" value="0.29498164014687883" />
         <entry key="app/src/main/res/layout/layout.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/main_activity.xml" value="0.19610507246376813" />
         <entry key="app/src/main/res/layout/main_fragment.xml" value="0.1" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,7 +11,7 @@ android {
 
     defaultConfig {
         applicationId "com.jusqre.greenpath"
-        minSdk 21
+        minSdk 24
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/app/src/main/java/com/jusqre/greenpath/ui/walk/WalkFragment.kt
+++ b/app/src/main/java/com/jusqre/greenpath/ui/walk/WalkFragment.kt
@@ -35,7 +35,7 @@ class WalkFragment : Fragment() {
         binding.buttonMakeTrail.setOnClickListener {
             Toast.makeText(this.context, "산책로 생성 클릭됨", Toast.LENGTH_SHORT).show()
             map?.let {
-                walkViewModel.startMakeTrail(it)
+                walkViewModel.startMakeTrail(it, this.requireContext())
             }
         }
 

--- a/app/src/main/java/com/jusqre/greenpath/ui/walk/WalkViewModel.kt
+++ b/app/src/main/java/com/jusqre/greenpath/ui/walk/WalkViewModel.kt
@@ -25,33 +25,35 @@ class WalkViewModel : ViewModel() {
     private lateinit var lookUpAlertDialog: AlertDialog.Builder
     private lateinit var makeTrailDialog: AlertDialog.Builder
     @SuppressLint("StaticFieldLeak")
-    private lateinit var rangeEditText: EditText
+    private lateinit var lookUpEditText: EditText
+    @SuppressLint("StaticFieldLeak")
+    private lateinit var makeTrailEditText: EditText
 
     fun startMakeTrail(map: TMapView, context: Context) {
         if (!::makeTrailDialog.isInitialized) {
             initMakeTrailAlertDialog(map, context)
         }
-        if (rangeEditText.parent != null) {
-            (rangeEditText.parent as ViewGroup).removeView(rangeEditText)
+        if (makeTrailEditText.parent != null) {
+            (makeTrailEditText.parent as ViewGroup).removeView(makeTrailEditText)
         }
         makeTrailDialog.create().show()
     }
 
     private fun initMakeTrailAlertDialog(map: TMapView, context: Context) {
-        rangeEditText = EditText(context)
-        rangeEditText.setText("")
+        makeTrailEditText = EditText(context)
+        makeTrailEditText.setText("")
         makeTrailDialog = AlertDialog.Builder(context).apply {
             setTitle("산책로 생성")
             setMessage("원하는 산책로 길이를 입력하십시오.(m)")
-            setView(rangeEditText)
+            setView(makeTrailEditText)
             setPositiveButton("OK"){ _: DialogInterface?, _: Int ->
-                TrailMaker(rangeEditText.text.toString().toInt(), map).start()
+                TrailMaker(makeTrailEditText.text.toString().toInt(), map).start()
             }
             setNeutralButton(
                 "RESET"
             ) { _: DialogInterface?, _: Int ->
                 map.removeAllTMapPolyLine()
-                rangeEditText.setText("")
+                makeTrailEditText.setText("")
             }
         }
     }
@@ -64,8 +66,8 @@ class WalkViewModel : ViewModel() {
         if (!::lookUpAlertDialog.isInitialized) {
             initLookUpAlertDialog(map, context)
         }
-        if (rangeEditText.parent != null) {
-            (rangeEditText.parent as ViewGroup).removeView(rangeEditText)
+        if (lookUpEditText.parent != null) {
+            (lookUpEditText.parent as ViewGroup).removeView(lookUpEditText)
         }
 
         lookUpAlertDialog.create().show()
@@ -73,12 +75,12 @@ class WalkViewModel : ViewModel() {
 
     /** AlertDialog 초기화 */
     private fun initLookUpAlertDialog(map: TMapView, context: Context) {
-        rangeEditText = EditText(context)
-        rangeEditText.setText("")
+        lookUpEditText = EditText(context)
+        lookUpEditText.setText("")
         lookUpAlertDialog = AlertDialog.Builder(context).apply {
             setTitle("산책로 조회")
             setMessage("산책로 조회 범위를 입력하십시오.(m)")
-            setView(rangeEditText)
+            setView(lookUpEditText)
             setPositiveButton("OK"){ _: DialogInterface?, _: Int ->
                 for (trail in dbTrailList) {
                     val tol = TMapPolyLine()
@@ -86,7 +88,7 @@ class WalkViewModel : ViewModel() {
                     tol.addLinePoint(
                         trail.tMapPoint
                     )
-                    if (tol.distance <= rangeEditText.text.toString().toInt()) {
+                    if (tol.distance <= lookUpEditText.text.toString().toInt()) {
                         map.addMarkerItem(
                             "${trail.hashCode()}",
                             trail.apply {
@@ -103,7 +105,7 @@ class WalkViewModel : ViewModel() {
                     i.visible = TMapMarkerItem.HIDDEN
                     map.setCenterPoint(map.longitude, map.latitude)
                 }
-                rangeEditText.setText("")
+                lookUpEditText.setText("")
             }
         }
     }

--- a/app/src/main/java/com/jusqre/greenpath/util/Converter.kt
+++ b/app/src/main/java/com/jusqre/greenpath/util/Converter.kt
@@ -1,0 +1,20 @@
+package com.jusqre.greenpath.util
+
+import com.skt.Tmap.TMapMarkerItem
+import com.skt.Tmap.TMapPoint
+import com.skt.Tmap.TMapPolyLine
+
+fun polyLine(currentNode: TMapPoint, o: TMapPoint): TMapPolyLine {
+    return TMapPolyLine().apply {
+        this.addLinePoint(currentNode)
+        this.addLinePoint(o)
+    }
+}
+
+fun marker(node: TMapPoint): TMapMarkerItem {
+    return TMapMarkerItem().apply {
+        latitude = node.latitude
+        longitude = node.longitude
+        visible = TMapMarkerItem.VISIBLE
+    }
+}

--- a/app/src/main/java/com/jusqre/greenpath/util/TrailMaker.kt
+++ b/app/src/main/java/com/jusqre/greenpath/util/TrailMaker.kt
@@ -1,0 +1,161 @@
+package com.jusqre.greenpath.util
+
+import com.skt.Tmap.TMapData
+import com.skt.Tmap.TMapPoint
+import com.skt.Tmap.TMapPolyLine
+import com.skt.Tmap.TMapView
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.lang.Exception
+import java.util.*
+import kotlin.math.abs
+import kotlin.math.cos
+
+class TrailMaker(private val distance: Int, private val map: TMapView) {
+    private lateinit var userPoint: TMapPoint
+    private lateinit var currentNode: TMapPoint
+    private lateinit var randomPointList: MutableList<TMapPoint>
+    private var quadrant = Array<PriorityQueue<TMapPoint>>(9) { PriorityQueue() }
+    private var phase = 0
+    private var totalDistance = 0.0
+    private val tMapData = TMapData()
+
+    fun start() = CoroutineScope(Dispatchers.Default).launch {
+        userPoint = LocationStore.lastTmapPoint
+        currentNode = userPoint
+        val startQuadrant = Random().nextInt(4) * 2 + 1
+        initRandomMarkerList(startQuadrant)
+        while (phase < 7) {
+            initQuadrant()
+            val peeked =
+                quadrant[if ((startQuadrant + phase) % 8 == 0) 8 else (startQuadrant + phase) % 8].peek()
+            if (peeked != null) {
+                checkInValidate(peeked)
+            }
+            if (peeked != null) {
+                totalDistance += polyLine(currentNode, peeked).distance
+                map.addMarkerItem(peeked.hashCode().toString(), marker(peeked).apply {
+                    calloutTitle = phase.toString()
+                    calloutSubTitle = totalDistance.toString()
+                    canShowCallout = true
+                })
+                map.addTMapPolyLine(phase.toString(), polyLine(currentNode, peeked))
+                currentNode = peeked
+            }
+            phase++
+        }
+        map.addTMapPolyLine(phase.toString(), polyLine(currentNode, userPoint))
+
+    }
+
+    private fun checkInValidate(peeked: TMapPoint) {
+        try {
+            val real = tMapData.findPathDataWithType(
+                TMapData.TMapPathType.PEDESTRIAN_PATH,
+                currentNode,
+                peeked
+            )
+            println(real.distance)
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun initRandomMarkerList(startQuadrant: Int) {
+        randomPointList = mutableListOf()
+        for (i in 0..2000) {
+            val tempLongitude = userPoint.longitude.randomLongitude(startQuadrant)
+            val tempLatitude = userPoint.latitude.randomLatitude(startQuadrant)
+            val tempPolyLine = TMapPolyLine().apply {
+                this.addLinePoint(userPoint)
+                this.addLinePoint(TMapPoint(tempLatitude, tempLongitude))
+            }
+            if (tempPolyLine.distance < distance / 2) {
+                randomPointList.add(TMapPoint(tempLatitude, tempLongitude))
+            }
+        }
+    }
+
+    private fun Double.randomLongitude(startQuadrant: Int): Double {
+        return this + 0.0000113 * distance / 2 * when (startQuadrant) {
+            1 -> (Math.random() * 2 - 1)
+            3 -> (Math.random() * -1)
+            5 -> (Math.random() * 2 - 1)
+            7 -> (Math.random())
+            else -> throw Exception("어디선가 잘못됨")
+        }
+    }
+
+    private fun Double.randomLatitude(startQuadrant: Int): Double {
+        return this + 0.000009 * distance / 2 * when (startQuadrant) {
+            1 -> (Math.random())
+            3 -> (Math.random() * 2 - 1)
+            5 -> (Math.random() * -1)
+            7 -> (Math.random() * 2 - 1)
+            else -> throw Exception("어디선가 잘못됨")
+        }
+    }
+
+    private fun initQuadrant() {
+        for (i in 1..8) {
+            quadrant[i] = PriorityQueue(pointComparator)
+        }
+        for (point in randomPointList) {
+            quadrant[finder(point, currentNode).value].add(point)
+        }
+        for (i in 1..8) {
+            println("$i = ${quadrant[i].size}")
+        }
+    }
+
+    private fun finder(target: TMapPoint, initial: TMapPoint): Quadrant {
+        val radian = cos((target.latitude + initial.latitude) * Math.PI / 360)
+        val cTarget = convert(target, radian)
+        val cInitial = convert(initial, radian)
+        return if (target.latitude - initial.latitude >= 0 && target.longitude - initial.longitude >= 0) {
+            if (cInitial.latitude + cTarget.longitude - cInitial.longitude > cTarget.latitude) {
+                Quadrant.FIRST_1
+            } else {
+                Quadrant.FIRST_2
+            }
+        } else if (target.latitude - initial.latitude >= 0 && target.longitude - initial.longitude <= 0) {
+            if (cInitial.latitude + cInitial.longitude - cTarget.longitude < cTarget.latitude) {
+                Quadrant.SECOND_1
+            } else {
+                Quadrant.SECOND_2
+            }
+        } else if (target.latitude - initial.latitude <= 0 && target.longitude - initial.longitude <= 0) {
+            if (cInitial.latitude - cInitial.longitude + cTarget.longitude < cTarget.latitude) {
+                Quadrant.THIRD_1
+            } else {
+                Quadrant.THIRD_2
+            }
+        } else if (target.latitude - initial.latitude <= 0 && target.longitude - initial.longitude >= 0) {
+            if (cInitial.latitude - cTarget.longitude + cInitial.longitude > cTarget.latitude) {
+                Quadrant.FOURTH_1
+            } else {
+                Quadrant.FOURTH_2
+            }
+        } else Quadrant.FIRST_1
+    }
+
+    private val pointComparator = Comparator<TMapPoint> { o1, o2 ->
+        (abs(polyLine(currentNode, o1).distance - (distance - totalDistance) / (8 - phase))
+                - abs(
+            polyLine(
+                currentNode,
+                o2
+            ).distance - (distance - totalDistance) / (8 - phase)
+        )).toInt()
+    }
+
+    private fun convert(point: TMapPoint, radian: Double): TMapPoint {
+        return TMapPoint(point.latitude, point.longitude * radian)
+    }
+}
+
+enum class Quadrant(val value: Int) {
+    FIRST_1(1), FIRST_2(2), SECOND_1(3), SECOND_2(4),
+    THIRD_1(5), THIRD_2(6), FOURTH_1(7), FOURTH_2(8)
+}

--- a/app/src/main/res/layout/fragment_walk.xml
+++ b/app/src/main/res/layout/fragment_walk.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:tools="http://schemas.android.com/tools">
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.walk.WalkFragment">
@@ -24,13 +23,15 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/white"
                 android:drawableTop="@drawable/ic_baseline_place_24"
+                android:drawableTint="@color/black"
                 android:text="@string/lookUpPath"
                 android:textColor="@color/black"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintHorizontal_weight="1"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toLeftOf="@id/buttonMakeTrail"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="UnusedAttribute" />
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/buttonMakeTrail"
@@ -38,13 +39,15 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/white"
                 android:drawableTop="@drawable/ic_baseline_near_me_24"
+                android:drawableTint="@color/black"
                 android:text="@string/makePath"
                 android:textColor="@color/black"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintHorizontal_weight="1"
                 app:layout_constraintLeft_toRightOf="@id/buttonRecommend"
                 app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="UnusedAttribute" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- 산책로 생성 기능 구현
   - 시작 시 Random().nextInt로 시작 사분면 선정
   - Equirectangular projection 이용하여 8개의 PriorityQueue(1_1사분면, 1_2사분면, 2_1사분면... 4_2사분면)에 Random Point 저장
      - pointComparator 구현하여  expectedDistance에 가까운(산책길이/8)에 가까운 순서대로 PriorityQueue에 저장
   - while(phase < 7) 안에서 각 phase에 따라 realPath가 null이 아닐때까지 pq.poll()
   - realPath를 찾은 후 투포인터를 통하여 expectedDistance에 가까운 subTMapPolyLine 반환 후 지도위에 표시
  
![feat_makeTrail](https://user-images.githubusercontent.com/76417969/185781262-3871241b-325f-42cd-b7e8-6b4d8a5cef56.gif)

- 추가 구현 예정사항
   - 다른 branch에서 Refactoring 예정
   - 테스트 후 산책로 생성시 겹치는 부분이 생긴다면 겹치는 부분 제거하는 로직 구현
